### PR TITLE
Linked List (releaseAll)

### DIFF
--- a/src/HID_Button_API.cpp
+++ b/src/HID_Button_API.cpp
@@ -77,6 +77,10 @@ HID_Button::~HID_Button() {
 	}
 }
 
+void HID_Button::releaseAll() {
+	releaseAll(HID_Button_Type::All);
+}
+
 // Release all buttons, using the linked list
 void HID_Button::releaseAll(HID_Button_Type releaseOnly) {
 	if (releaseOnly == HID_Button_Type::None) return;

--- a/src/HID_Button_API.cpp
+++ b/src/HID_Button_API.cpp
@@ -26,6 +26,57 @@
 
 #include "HID_Button_API.h"
 
+HID_Button * HID_Button::head = nullptr;
+HID_Button * HID_Button::tail = nullptr;
+
+HID_Button::HID_Button() {
+	// If linked list is empty, set both head and tail
+	if (head == nullptr) {
+		head = this;
+		tail = this;
+	}
+	// If linked list is *not* empty, set the 'next' ptr of the tail
+	// and update the tail
+	else {
+		tail->next = this;
+		tail = this;
+	}
+}
+
+HID_Button::~HID_Button() {
+	// If we're at the start of the list...
+	if (this == head) {
+		// Option #1: Only element in the list
+		if (this == tail) {
+			head = nullptr;
+			tail = nullptr;  // List is now empty
+		}
+		// Option #2: First element in the list,
+		// but not *only* element
+		else {
+			head = next;  // Set head to next, and we're done
+		}
+		return;
+	}
+
+	// Option #3: Somewhere else in the list.
+	// Iterate through to find it
+	HID_Button * ptr = head;
+
+	while (ptr != nullptr) {
+		if (ptr->next == this) {  // FOUND!
+			ptr->next = next;  // Set the previous "next" as this entry's "next" (skip this object)
+			break;  // Stop searching
+		}
+		ptr = ptr->next;  // Not found. Next entry...
+	}
+
+	// Option #4: Last entry in the list
+	if (this == tail) {
+		tail = ptr;  // Set the tail as the previous entry
+	}
+}
+
 void HID_Button::press() {
 	set(true);
 }

--- a/src/HID_Button_API.cpp
+++ b/src/HID_Button_API.cpp
@@ -78,11 +78,16 @@ HID_Button::~HID_Button() {
 }
 
 // Release all buttons, using the linked list
-void HID_Button::releaseAll() {
+void HID_Button::releaseAll(HID_Button_Type releaseOnly) {
+	if (releaseOnly == HID_Button_Type::None) return;
+
 	HID_Button * ptr = head;
 
 	while (ptr != nullptr) {
-		ptr->release();
+		// Check if type matches before releasing
+		if (releaseOnly == HID_Button_Type::All || releaseOnly == ptr->getType()) {
+			ptr->release();
+		}
 		ptr = ptr->next;
 	}
 }

--- a/src/HID_Button_API.cpp
+++ b/src/HID_Button_API.cpp
@@ -77,6 +77,16 @@ HID_Button::~HID_Button() {
 	}
 }
 
+// Release all buttons, using the linked list
+void HID_Button::releaseAll() {
+	HID_Button * ptr = head;
+
+	while (ptr != nullptr) {
+		ptr->release();
+		ptr = ptr->next;
+	}
+}
+
 void HID_Button::press() {
 	set(true);
 }

--- a/src/HID_Button_API.h
+++ b/src/HID_Button_API.h
@@ -46,7 +46,7 @@ public:
 	HID_Button();
 	~HID_Button();
 
-	static void releaseAll(HID_Button_Type limitTo = HID_Button_Type::All);
+	static void releaseAll();
 
 	void press();
 	void release();
@@ -61,6 +61,7 @@ public:
 	virtual HID_Button_Type getType() const = 0;
 
 protected:
+	static void releaseAll(HID_Button_Type limitTo);
 	virtual void sendState(boolean state) = 0;
 
 	boolean pressed = false;

--- a/src/HID_Button_API.h
+++ b/src/HID_Button_API.h
@@ -39,6 +39,9 @@ enum class HID_Button_Type {
 
 class HID_Button {
 public:
+	HID_Button();
+	~HID_Button();
+
 	void press();
 	void release();
 
@@ -55,6 +58,12 @@ protected:
 	virtual void sendState(boolean state) = 0;
 
 	boolean pressed = false;
+
+private:
+	static HID_Button * head;
+	static HID_Button * tail;
+
+	HID_Button * next = nullptr;
 };
 
 #endif

--- a/src/HID_Button_API.h
+++ b/src/HID_Button_API.h
@@ -42,6 +42,8 @@ public:
 	HID_Button();
 	~HID_Button();
 
+	static void releaseAll();
+
 	void press();
 	void release();
 

--- a/src/HID_Button_API.h
+++ b/src/HID_Button_API.h
@@ -30,11 +30,15 @@
 #include <Arduino.h>
 
 enum class HID_Button_Type {
-	None,
+	// Variants
 	Keyboard,
 	Mouse,
 	Joystick,
 	Custom,
+
+	// Meta Options
+	All,
+	None,
 };
 
 class HID_Button {
@@ -42,7 +46,7 @@ public:
 	HID_Button();
 	~HID_Button();
 
-	static void releaseAll();
+	static void releaseAll(HID_Button_Type limitTo = HID_Button_Type::All);
 
 	void press();
 	void release();

--- a/src/variants/HID_Button_Joystick.h
+++ b/src/variants/HID_Button_Joystick.h
@@ -37,6 +37,10 @@ public:
 	JoystickButton(uint8_t b) :
 		buttonNumber(b) {}
 
+	static void releaseAll() {
+		HID_Button::releaseAll(HID_Button_Type::Joystick);
+	}
+
 	uint16_t getButton() const {
 		return buttonNumber;
 	}

--- a/src/variants/HID_Button_Keyboard.h
+++ b/src/variants/HID_Button_Keyboard.h
@@ -35,6 +35,10 @@ public:
 	KeyboardButton(char k) :
 		key(k) {}
 
+	static void releaseAll() {
+		HID_Button::releaseAll(HID_Button_Type::Keyboard);
+	}
+
 	uint16_t getButton() const {
 		return key;
 	}

--- a/src/variants/HID_Button_Mouse.h
+++ b/src/variants/HID_Button_Mouse.h
@@ -35,6 +35,10 @@ public:
 	MouseButton(uint8_t b) :
 		buttonID(b) {}
 
+	static void releaseAll() {
+		HID_Button::releaseAll(HID_Button_Type::Mouse);
+	}
+
 	uint16_t getButton() const {
 		return buttonID;
 	}
@@ -42,8 +46,6 @@ public:
 	HID_Button_Type getType() const {
 		return HID_Button_Type::Mouse;
 	}
-
-	static const HID_Button_Type HID_Type = HID_Button_Type::Mouse;
 
 protected:
 	void sendState(boolean state) {


### PR DESCRIPTION
Builds a linked list connecting all of the button objects. Allows easy clearing of all 'pressed' buttons, and potentially allows controlling all inputs simultaneously (although that's not really what it's meant for).

The static `releaseAll` function takes a type parameter (classed enum) that allows the user to limit what HID types to release. This is masked with a separate static function for every HID type, enabling the user to only release one HID type at a time if need be.