### PR TITLE
Teensy Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,5 +35,7 @@ The library currently supports three HID button types:
 * [Mouse](https://www.arduino.cc/reference/en/language/functions/usb/mouse/)
 * [Joystick](https://github.com/MHeironimus/ArduinoJoystickLibrary)
 
+All three of these HID types are also supported on the Teensy using its native libraries.
+
 ## License
 Released under the terms of the permissive [MIT license](https://opensource.org/licenses/MIT). See the [LICENSE](LICENSE) file for more information.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This small Arduino library makes it easier to set up programs that use Keyboard,
 	ButtonA.set(stickY < -300);
 ```
 
-All HID button types share a common base class and be treated identically, allowing you to share logic between buttons on composite devices (e.g. Keyboard + Mouse).
+All HID button types share a common base class and are treated identically, allowing you to share logic between buttons on composite devices (e.g. Keyboard + Mouse).
 
 ## Supported HID Types
 The library currently supports three HID button types:

--- a/examples/JoystickButton/JoystickButton.ino
+++ b/examples/JoystickButton/JoystickButton.ino
@@ -38,12 +38,16 @@ Joystick_ Joystick(JOYSTICK_DEFAULT_REPORT_ID, JOYSTICK_TYPE_GAMEPAD,
 	false, false, false,    // No Rx, Ry, or Rz
 	false, false,           // No rudder or throttle
 	false, false, false);   // No accelerator, brake, or steering
+
+const uint8_t ButtonOffset = 1; // Arduino Joystick buttons are indexed at 0
+#else
+const uint8_t ButtonOffset = 0;  // Teensy Joystick buttons are indexed at 1
 #endif
 
 #include <HID_Buttons.h>  // Must import AFTER Joystick.h
 
 const uint8_t ButtonPin = 6;  // Pin for hardware button
-const uint8_t ButtonNumber = 0;  // Press this Joystick button # when the pin is grounded
+const uint8_t ButtonNumber = 1 - ButtonOffset;  // Press this Joystick button # when the pin is grounded
 
 JoystickButton myButton(ButtonNumber);
 

--- a/examples/JoystickButton/JoystickButton.ino
+++ b/examples/JoystickButton/JoystickButton.ino
@@ -29,8 +29,8 @@
  *
  */
 
+#ifndef TEENSYDUINO
 #include <Joystick.h>  // Use MHeironimus's Joystick library
-#include <HID_Buttons.h>  // Must import AFTER Joystick.h
 
 Joystick_ Joystick(JOYSTICK_DEFAULT_REPORT_ID, JOYSTICK_TYPE_GAMEPAD,
 	10, 0,                  // Button Count, Hat Switch Count
@@ -38,6 +38,9 @@ Joystick_ Joystick(JOYSTICK_DEFAULT_REPORT_ID, JOYSTICK_TYPE_GAMEPAD,
 	false, false, false,    // No Rx, Ry, or Rz
 	false, false,           // No rudder or throttle
 	false, false, false);   // No accelerator, brake, or steering
+#endif
+
+#include <HID_Buttons.h>  // Must import AFTER Joystick.h
 
 const uint8_t ButtonPin = 6;  // Pin for hardware button
 const uint8_t ButtonNumber = 0;  // Press this Joystick button # when the pin is grounded

--- a/src/variants/HID_Button_Joystick.h
+++ b/src/variants/HID_Button_Joystick.h
@@ -29,8 +29,24 @@
 
 #include "HID_Button_API.h"
 
-#if defined(JOYSTICK_h)
-extern Joystick_ Joystick;
+ /*
+  * Include Guard Info
+  * --------------------
+  *
+  * Arduino Boards:
+  *     JOYSTICK_h   MHeironimus header include guard (pluggable HID)
+  *     USB_CON      defined by the architecture if USB support exists
+  *
+  * Teensy:
+  *     TEENSYDUINO             defined if using any Teensy board
+  *     USB_HID                 defined by boards.txt if using USB type "Keyboard + Mouse + Joystick"
+  *     USB_SERIAL_HID          defined by boards.txt if using USB type "Serial + Keyboard + Mouse + Joystick"
+  *     USB_FLIGHTSIM_JOYSTICK  defined by boards.txt if using USB type "Flight Sim Controls + Joystick"
+  */
+
+#if (defined(JOYSTICK_h) && defined(USBCON)) || \
+	(defined(TEENSYDUINO) && \
+	(defined(USB_HID) || defined(USB_SERIAL_HID) || defined(USB_FLIGHTSIM_JOYSTICK)))
 
 class JoystickButton : public HID_Button {
 public:
@@ -51,7 +67,12 @@ public:
 
 protected:
 	void sendState(boolean state) {
-		Joystick.setButton(buttonNumber, state);
+		#if defined(JOYSTICK_h)  // MHeironimus library
+			extern Joystick_ Joystick;  // Using the expected name for the object
+			Joystick.setButton(buttonNumber, state);
+		#elif defined(TEENSYDUINO)
+			Joystick.button(buttonNumber, state);
+		#endif
 	}
 
 	const uint8_t buttonNumber;

--- a/src/variants/HID_Button_Keyboard.h
+++ b/src/variants/HID_Button_Keyboard.h
@@ -29,10 +29,38 @@
 
 #include "HID_Button_API.h"
 
-#if defined(KEYBOARD_h) && defined(_USING_HID)
+ /*
+  * Include Guard Info
+  * --------------------
+  *
+  * Arduino Boards:
+  *     KEYBOARD_h   built-in library header include guard
+  *     _USING_HID   defined in HID.h if USB is enabled (USBCON)
+  *
+  * Teensy:
+  *     TEENSYDUINO       defined if using any Teensy board
+  *     USB_KEYBOARDONLY  defined by boards.txt if using USB type "Keyboard"
+  *     USB_HID           defined by boards.txt if using USB type "Keyboard + Mouse + Joystick"
+  *     USB_SERIAL_HID    defined by boards.txt if using USB type "Serial + Keyboard + Mouse + Joystick"
+  *     USB_TOUCHSCREEN      defined by boards.txt if using USB type "Keyboard + Touch Screen"
+  *     USB_HID_TOUCHSCREEN  defined by boards.txt if using USB type "Keyboard + Mouse + Touch Screen"
+  */
+
+#if (defined(KEYBOARD_h) && defined(_USING_HID)) || \
+	(defined(TEENSYDUINO) && \
+	(defined(USB_KEYBOARDONLY) || defined(USB_HID) || defined(USB_SERIAL_HID) \
+	 || defined(USB_TOUCHSCREEN) || defined(USB_HID_TOUCHSCREEN)))
+
 class KeyboardButton : public HID_Button {
 public:
-	KeyboardButton(char k) :
+
+#ifdef TEENSYDUINO
+	using KeySize = uint16_t;
+#else
+	using KeySize = uint8_t;
+#endif
+
+	KeyboardButton(KeySize k) :
 		key(k) {}
 
 	static void releaseAll() {
@@ -52,7 +80,7 @@ protected:
 		state ? Keyboard.press(key) : Keyboard.release(key);
 	}
 
-	const char key;
+	const KeySize key;
 };
 #endif
 

--- a/src/variants/HID_Button_Mouse.h
+++ b/src/variants/HID_Button_Mouse.h
@@ -29,7 +29,24 @@
 
 #include "HID_Button_API.h"
 
-#if defined(MOUSE_h) && defined(_USING_HID)
+/*
+ * Include Guard Info
+ * --------------------
+ *
+ * Arduino Boards:
+ *     MOUSE_h      built-in library header include guard
+ *     _USING_HID   defined in HID.h if USB is enabled (USBCON)
+ *
+ * Teensy:
+ *     TEENSYDUINO     defined if using any Teensy board
+ *     USB_HID         defined by boards.txt if using USB type "Keyboard + Mouse + Joystick"
+ *     USB_SERIAL_HID  defined by boards.txt if using USB type "Serial + Keyboard + Mouse + Joystick"
+ */
+
+#if (defined(MOUSE_h) && defined(_USING_HID)) || \
+	(defined(TEENSYDUINO) && \
+	(defined (USB_HID) || defined(USB_SERIAL_HID)))
+
 class MouseButton : public HID_Button {
 public:
 	MouseButton(uint8_t b) :


### PR DESCRIPTION
Adds support for the built-in libraries used with the [Teensy boards](https://www.pjrc.com/teensy/) (tested with a Teensy LC). These are designed to be drop-in replacements for the Arduino libraries, so this was pretty straight-forward:

**Mouse**: 
* No changes

**Keyboard**:
* Use a different key storage size for Teensy. Modifier keys on the Teensy can take up to two bytes.

**Joystick**:
* Use Teensy output function (different name)
* Don't use `extern` Joystick reference with Teensy
* Examples: Don't include header / define Joystick instance with Teensy
* Examples: Offset button index by 1 and add conditional offset variable

All three currently supported HID variants also received an update to their include guards to add the supported HID button classes when the proper Teensy USB modes are set.