### PR TITLE
Button Type Define Flags

### DIFF
--- a/extras/Adding New Button Types.md
+++ b/extras/Adding New Button Types.md
@@ -25,6 +25,12 @@ Next, add some guards so that the button class is only defined when the relevant
 #endif
 ```
 
+Immediately after this you should define your own flag for the HID type. This is so that the user can easily test whether the button type exists in their own code:
+
+```cpp
+#define HID_BUTTON_MOUSE
+```
+
 Inside of this `#if` block is the button class definition. Start by importing the base class, `HID_Button`, using public inheritance:
 
 ```cpp

--- a/src/variants/HID_Button_Joystick.h
+++ b/src/variants/HID_Button_Joystick.h
@@ -48,6 +48,8 @@
 	(defined(TEENSYDUINO) && \
 	(defined(USB_HID) || defined(USB_SERIAL_HID) || defined(USB_FLIGHTSIM_JOYSTICK)))
 
+#define HID_BUTTON_JOYSTICK
+
 class JoystickButton : public HID_Button {
 public:
 	JoystickButton(uint8_t b) :

--- a/src/variants/HID_Button_Keyboard.h
+++ b/src/variants/HID_Button_Keyboard.h
@@ -51,6 +51,8 @@
 	(defined(USB_KEYBOARDONLY) || defined(USB_HID) || defined(USB_SERIAL_HID) \
 	 || defined(USB_TOUCHSCREEN) || defined(USB_HID_TOUCHSCREEN)))
 
+#define HID_BUTTON_KEYBOARD
+
 class KeyboardButton : public HID_Button {
 public:
 

--- a/src/variants/HID_Button_Mouse.h
+++ b/src/variants/HID_Button_Mouse.h
@@ -47,6 +47,8 @@
 	(defined(TEENSYDUINO) && \
 	(defined (USB_HID) || defined(USB_SERIAL_HID)))
 
+#define HID_BUTTON_MOUSE
+
 class MouseButton : public HID_Button {
 public:
 	MouseButton(uint8_t b) :


### PR DESCRIPTION
Small PR to add preprocessor defines within each button type's include guard. This makes it easy to check whether a given button class exists in the main program without having to check against the board-specific HID implementation guards.